### PR TITLE
Fix default scheme params

### DIFF
--- a/migrations/helpers/schemeUtils.js
+++ b/migrations/helpers/schemeUtils.js
@@ -5,7 +5,7 @@ async function registerScheme({
   web3,
   label,
   schemeAddress,
-  paramsHash = web3.utils.asciiToHex('0'),
+  paramsHash = web3.utils.asciiToHex(0),
   permissions = SchemePermissions.REGISTERED,
   avatarAddress,
   controller

--- a/migrations/helpers/schemeUtils.js
+++ b/migrations/helpers/schemeUtils.js
@@ -5,7 +5,7 @@ async function registerScheme({
   web3,
   label,
   schemeAddress,
-  paramsHash = web3.utils.asciiToHex(0),
+  paramsHash = web3.utils.toHex(0),
   permissions = SchemePermissions.REGISTERED,
   avatarAddress,
   controller


### PR DESCRIPTION
For the schemes not defining any param hash on their registration, there was an error in the default being used.

It was using 0x30 instead of 0x00.

The following picture illustrates why.

![image](https://user-images.githubusercontent.com/2352112/58385015-c1ae2100-7fea-11e9-8c1a-4fdd0ac0af85.png)
